### PR TITLE
Adding .Device to line 1 of test.js fixes error

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-let CT = require('./index');
+let CT = require('./index').Device;
 var fs = require('fs');
 var PNG = require('pngjs').PNG;
 const grafikk = require('@bitfocusas/grafikk');


### PR DESCRIPTION
Fixes #18 and allows connection to loupedeck-live - header mismatch because this was intended for loupedeck-ct. 

```
 phocking   18_phillhocking-ct-not-constructor  ~  Workspace  pr  loupedeck-ct  node test.js 
[CT] Construct
[CT] Connect()
[CT] Connect()
Connect Error: Error: Sec-WebSocket-Accept header from server didn't match expected value of irfWSzN5uSYCkVFv8VpAT22UhjY=
[CT] Connect
connected!!
CT Event {
  action: 'device_serial',
  value: 'WebSoc\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
}
CT Event { action: 'device_serial', value: 'LDD2001014021160700838B0005' }
^C
```